### PR TITLE
Add histogram bin boundary computation and yaml export

### DIFF
--- a/src/atlas_object_partitioning/__init__.py
+++ b/src/atlas_object_partitioning/__init__.py
@@ -2,3 +2,4 @@
 from .core import *
 from .partition import *
 from .scan_ds import *
+from .histograms import *

--- a/src/atlas_object_partitioning/histograms.py
+++ b/src/atlas_object_partitioning/histograms.py
@@ -1,0 +1,51 @@
+import numpy as np
+import awkward as ak
+from typing import Dict, List
+from pydantic import BaseModel
+import yaml
+
+
+def _compute_boundaries(values: ak.Array) -> List[int]:
+    """Compute 3 boundary values that split the distribution into 4 bins.
+
+    Parameters
+    ----------
+    values: ak.Array
+        Array of values for a single axis.
+    Returns
+    -------
+    List[int]
+        List of boundary values (upper edge of 1st, 2nd, 3rd quartiles).
+    """
+    if len(values) == 0:
+        return []
+    min_val = int(ak.min(values))
+    max_val = int(ak.max(values))
+    bins = np.arange(min_val, max_val + 2)
+    hist, edges = np.histogram(values, bins=bins)
+    cdf = np.cumsum(hist)
+    quarter = cdf[-1] / 4
+    boundaries: List[int] = []
+    for i in range(1, 4):
+        idx = int(np.searchsorted(cdf, quarter * i))
+        boundaries.append(int(edges[idx + 1]))
+    return boundaries
+
+
+def compute_bin_boundaries(data: ak.Array) -> Dict[str, List[int]]:
+    """Compute bin boundaries for all axes in the awkward array."""
+    result: Dict[str, List[int]] = {}
+    for axis in data.fields:
+        result[axis] = _compute_boundaries(data[axis])
+    return result
+
+
+class BinBoundaries(BaseModel):
+    axes: Dict[str, List[int]]
+
+
+def write_bin_boundaries_yaml(boundaries: Dict[str, List[int]], file_path: str) -> None:
+    """Write the bin boundaries to ``file_path`` in YAML format."""
+    data = BinBoundaries(axes=boundaries)
+    with open(file_path, "w") as f:
+        yaml.safe_dump(data.model_dump(), f)

--- a/tests/atlas_object_partitioning/test_histograms.py
+++ b/tests/atlas_object_partitioning/test_histograms.py
@@ -1,0 +1,20 @@
+import os
+import yaml
+import awkward as ak
+from atlas_object_partitioning.histograms import compute_bin_boundaries, write_bin_boundaries_yaml
+
+
+def test_compute_bin_boundaries(tmp_path):
+    data = ak.Array({
+        'n_muons': [0,1,1,2,2,2,3,3,4,4],
+        'n_electrons': [1,2,1,0,1,2,3,3,2,0]
+    })
+    boundaries = compute_bin_boundaries(data)
+    assert boundaries['n_muons'] == [2, 3, 4]
+    assert boundaries['n_electrons'] == [2, 2, 3]
+
+    out_file = tmp_path / 'bounds.yaml'
+    write_bin_boundaries_yaml(boundaries, out_file)
+    with open(out_file) as f:
+        loaded = yaml.safe_load(f)
+    assert loaded == {'axes': boundaries}


### PR DESCRIPTION
## Summary
- compute histogram-based bin boundaries for each object count axis
- allow writing boundaries via pydantic to YAML
- expose new functions via `__init__`
- add unit tests for boundary calculation and YAML output

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880e7e711b88320af3499b5b96344a6