### PR TITLE
Persist hist objects in pickle files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,3 +132,4 @@ cython_debug/
 *.parquet
 servicex.yaml
 bin_boundaries.yaml
+histogram.pkl

--- a/README.md
+++ b/README.md
@@ -5,7 +5,18 @@
 
 A Python package to help understand partitioning by objects. Works only on ATLAS xAOD format files (PHYS, PHYSLITE, etc.).
 
-Writes a `parquet` file with per-event data.
+Writes a `parquet` file with per-event data, a `bin_boundaries.yaml` files, and a python pickle file with an n-dimensional histogram.
+
+- Each *axis* is a count of PHYSLITE objects (muons, electrons, jets, etc).
+- Looks at each axis and tries to divide the counts into 4 bins of equal #s of events.
+- Then sub-divides each bin of axis 1 by axis 2 and axis 3 etc (making a
+    n-dimensional histogram).
+- Saves the binning and histogram to files.
+- Prints out a table with the 10 largest and smallest bins.
+
+Use `--help` to see available options.
+
+
 
 ## Installation
 
@@ -15,7 +26,7 @@ Install via **pip**:
 pip install atlas-object-partitioning
 ```
 
-Install via `uv`:
+Run via `uv`:
 
 * If you don't have the [`uv` tool installed](https://docs.astral.sh/uv/getting-started/installation/), it is highly recommended as a way to quickly install local versions of the code without having to build custom environments, etc.
 
@@ -28,7 +39,7 @@ atlas-object-partitioning --help
 
 Update it to the most recent version with `uv tool upgrade atlas-object-partitioning`.
 
-Or running it in an **ephemeral environment**:
+Or running it in an **ephemeral environment** (recommended for intermittent or one-off use):
 
 ```bash
 uvx atlas-object-partitioning --help

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "servicex_analysis_utils",
     "jinja2",
     "pyarrow",
+    "hist",
 ]
 
 [project.optional-dependencies]

--- a/src/atlas_object_partitioning/core.py
+++ b/src/atlas_object_partitioning/core.py
@@ -1,2 +1,0 @@
-def dummy_function():
-    return True

--- a/src/atlas_object_partitioning/histograms.py
+++ b/src/atlas_object_partitioning/histograms.py
@@ -94,7 +94,7 @@ def build_nd_histogram(data: ak.Array, boundaries: Dict[str, List[int]]) -> Base
     return h
 
 
-def write_histogram_pickle(hist: Hist, file_path: str) -> None:
+def write_histogram_pickle(hist: BaseHist, file_path: str) -> None:
     """Persist the histogram to disk using :mod:`pickle`.
     This currently is the most efficient way to store the histogram
     according to the histogram authors. A new serialization method that
@@ -113,7 +113,7 @@ def load_histogram_pickle(file_path: str) -> Hist:
 
 
 def _sorted_bin_records(
-    hist: Hist,
+    hist: BaseHist,
     n: int,
     ascending: bool = False,
 ) -> List[Dict[str, object]]:
@@ -141,12 +141,12 @@ def _sorted_bin_records(
     return records
 
 
-def top_bins(hist: Hist, n: int = 10) -> List[Dict[str, object]]:
+def top_bins(hist: BaseHist, n: int = 10) -> List[Dict[str, object]]:
     """Return summary information for the top ``n`` populated bins."""
     return _sorted_bin_records(hist, n, ascending=False)
 
 
-def bottom_bins(hist: Hist, n: int = 10) -> List[Dict[str, object]]:
+def bottom_bins(hist: BaseHist, n: int = 10) -> List[Dict[str, object]]:
     """Return summary information for the least ``n`` populated bins."""
     return _sorted_bin_records(hist, n, ascending=True)
 

--- a/src/atlas_object_partitioning/histograms.py
+++ b/src/atlas_object_partitioning/histograms.py
@@ -1,13 +1,13 @@
-import numpy as np
-import awkward as ak
-from typing import Dict, List
-from pydantic import BaseModel
-import yaml
-from typing import Tuple
-from rich.table import Table
-from rich.console import Console
-from hist import BaseHist, Hist
 import pickle
+from typing import Dict, List
+
+import awkward as ak
+import numpy as np
+import yaml
+from hist import BaseHist, Hist
+from pydantic import BaseModel
+from rich.console import Console
+from rich.table import Table
 
 
 def _compute_boundaries(values: ak.Array) -> List[int]:
@@ -150,14 +150,14 @@ def print_bin_table(records: List[Dict[str, object]], title: str) -> None:
     """Print summary table for ``records`` using ``rich``."""
     if not records:
         return
-    axes = list(records[0]["bin"].keys())
+    axes = list(records[0]["bin"].keys())  # type: ignore
     table = Table(title=title)
     for ax in axes:
         table.add_column(ax)
     table.add_column("count", justify="right")
     table.add_column("fraction", justify="right")
     for r in records:
-        row = [f"[{lo}, {hi})" for lo, hi in r["bin"].values()]
+        row = [f"[{lo}, {hi})" for lo, hi in r["bin"].values()]  # type: ignore
         row.append(f"{r['count']:,}")
         row.append(f"{r['fraction']:.3f}")
         table.add_row(*row)

--- a/src/atlas_object_partitioning/histograms.py
+++ b/src/atlas_object_partitioning/histograms.py
@@ -3,6 +3,11 @@ import awkward as ak
 from typing import Dict, List
 from pydantic import BaseModel
 import yaml
+from typing import Tuple
+from rich.table import Table
+from rich.console import Console
+from hist import Hist
+import pickle
 
 
 def _compute_boundaries(values: ak.Array) -> List[int]:
@@ -56,3 +61,104 @@ def write_bin_boundaries_yaml(boundaries: Dict[str, List[int]], file_path: str) 
     data = BinBoundaries(axes=boundaries)
     with open(file_path, "w") as f:
         yaml.safe_dump(data.model_dump(), f)
+
+
+def build_nd_histogram(
+    data: ak.Array, boundaries: Dict[str, List[int]]
+) -> Hist:
+    """Build an n-dimensional histogram using ``boundaries`` and return a
+    :class:`hist.Hist` object.
+
+    Parameters
+    ----------
+    data:
+        Event-by-event counts of objects.
+    boundaries:
+        Mapping from axis name to bin boundaries.
+
+    Returns
+    -------
+    ``hist.Hist`` instance populated with the supplied data.
+    """
+    axes = list(boundaries.keys())
+
+    # Build the histogram using ``hist`` which leverages boost-histogram
+    h_builder = Hist.new
+    for ax in axes:
+        h_builder = h_builder.Var(boundaries[ax], name=ax, label=ax)
+    h_builder = h_builder.Int64()
+    h = h_builder()
+
+    # Fill with event counts
+    fill_dict = {ax: ak.to_numpy(data[ax]) for ax in axes}
+    h.fill(**fill_dict)
+
+    return h
+
+
+def write_histogram_pickle(hist: Hist, file_path: str) -> None:
+    """Persist the histogram to disk using :mod:`pickle`."""
+    with open(file_path, "wb") as f:
+        pickle.dump(hist, f)
+
+
+def load_histogram_pickle(file_path: str) -> Hist:
+    """Load a histogram previously written with :func:`write_histogram_pickle`."""
+    with open(file_path, "rb") as f:
+        hist = pickle.load(f)
+    return hist
+
+
+def _sorted_bin_records(
+    hist: Hist,
+    n: int,
+    ascending: bool = False,
+) -> List[Dict[str, object]]:
+    counts = np.asarray(hist.view())
+    flat = counts.flatten()
+    total = int(flat.sum())
+    order = np.argsort(flat)
+    if not ascending:
+        order = order[::-1]
+    records = []
+    edges = [np.asarray(ax.edges) for ax in hist.axes]
+    axes_names = [ax.name if ax.name is not None else f"axis_{i}" for i, ax in enumerate(hist.axes)]
+    for idx in order[:n]:
+        count = int(flat[idx])
+        frac = 0.0 if total == 0 else float(count) / float(total)
+        bin_idx = np.unravel_index(idx, counts.shape)
+        label = {
+            name: (edges[i][b], edges[i][b + 1])
+            for i, (name, b) in enumerate(zip(axes_names, bin_idx))
+        }
+        records.append({"bin": label, "count": count, "fraction": frac})
+    return records
+
+
+def top_bins(hist: Hist, n: int = 10) -> List[Dict[str, object]]:
+    """Return summary information for the top ``n`` populated bins."""
+    return _sorted_bin_records(hist, n, ascending=False)
+
+
+def bottom_bins(hist: Hist, n: int = 10) -> List[Dict[str, object]]:
+    """Return summary information for the least ``n`` populated bins."""
+    return _sorted_bin_records(hist, n, ascending=True)
+
+
+def print_bin_table(records: List[Dict[str, object]], title: str) -> None:
+    """Print summary table for ``records`` using ``rich``."""
+    if not records:
+        return
+    axes = list(records[0]["bin"].keys())
+    table = Table(title=title)
+    for ax in axes:
+        table.add_column(ax)
+    table.add_column("count", justify="right")
+    table.add_column("fraction", justify="right")
+    for r in records:
+        row = [f"[{lo}, {hi})" for lo, hi in r["bin"].values()]
+        row.append(str(r["count"]))
+        row.append(f"{r['fraction']:.3f}")
+        table.add_row(*row)
+    Console().print(table)
+

--- a/src/atlas_object_partitioning/histograms.py
+++ b/src/atlas_object_partitioning/histograms.py
@@ -95,7 +95,12 @@ def build_nd_histogram(data: ak.Array, boundaries: Dict[str, List[int]]) -> Base
 
 
 def write_histogram_pickle(hist: Hist, file_path: str) -> None:
-    """Persist the histogram to disk using :mod:`pickle`."""
+    """Persist the histogram to disk using :mod:`pickle`.
+    This currently is the most efficient way to store the histogram
+    according to the histogram authors. A new serialization method that
+    should be cross-program (e.g. ROOT should be able to read it) is
+    coming.
+    """
     with open(file_path, "wb") as f:
         pickle.dump(hist, f)
 

--- a/src/atlas_object_partitioning/partition.py
+++ b/src/atlas_object_partitioning/partition.py
@@ -22,7 +22,8 @@ def main(
         None,
         "--output",
         "-o",
-        help="Output file name for the object counts parquet file. If not provided, will not save to file.",
+        help="Output file name for the object counts parquet file. If not provided, will not "
+        "save to file.",
     ),
     n_files: int = typer.Option(
         1,

--- a/src/atlas_object_partitioning/partition.py
+++ b/src/atlas_object_partitioning/partition.py
@@ -4,6 +4,11 @@ from atlas_object_partitioning.scan_ds import collect_object_counts
 from atlas_object_partitioning.histograms import (
     compute_bin_boundaries,
     write_bin_boundaries_yaml,
+    build_nd_histogram,
+    write_histogram_pickle,
+    top_bins,
+    bottom_bins,
+    print_bin_table,
 )
 
 app = typer.Typer()
@@ -46,6 +51,14 @@ def main(
 
     simple_boundaries = compute_bin_boundaries(counts)
     write_bin_boundaries_yaml(simple_boundaries, "bin_boundaries.yaml")
+
+    hist = build_nd_histogram(counts, simple_boundaries)
+    write_histogram_pickle(hist, "histogram.pkl")
+
+    top = top_bins(hist, n=10)
+    bottom = bottom_bins(hist, n=10)
+    print_bin_table(top, "Top 10 bins")
+    print_bin_table(bottom, "Least 10 bins")
 
 
 if __name__ == "__main__":

--- a/tests/atlas_object_partitioning/test_histograms.py
+++ b/tests/atlas_object_partitioning/test_histograms.py
@@ -50,15 +50,15 @@ def test_histogram_build_and_io(tmp_path):
     )
     bounds = compute_bin_boundaries(data)
     hist = build_nd_histogram(data, bounds)
-    assert hist.view().sum() == len(data)
+    assert hist.view().sum() == len(data)  # type: ignore
 
     file = tmp_path / "hist.pkl"
-    write_histogram_pickle(hist, file)
+    write_histogram_pickle(hist, file)  # type: ignore
     hist2 = load_histogram_pickle(file)
 
     assert hist2.axes[0].size == hist.axes[0].size
-    assert np.allclose(hist2.view(), hist.view())
-    assert hist2.view().sum() == len(data)
+    assert np.allclose(hist2.view(), hist.view())  # type: ignore
+    assert hist2.view().sum() == len(data)  # type: ignore
 
     top = top_bins(hist2, n=1)[0]
     assert "count" in top and "fraction" in top


### PR DESCRIPTION
## Summary
- store `Hist` objects with `pickle` instead of numpy arrays
- update table helper functions to operate on `Hist`
- adjust CLI and tests for new histogram persistence
- Update README and `--help` text
- Other clean up work

------
https://chatgpt.com/codex/tasks/task_e_68810c2126e4832098ec7914cd9dc268