### PR TITLE
Repartition bin boundaries and update merged cell counts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,3 +134,4 @@ servicex.yaml
 bin_boundaries.yaml
 histogram.pkl
 .devcontainer/.servicex.yaml.tmp
+bin_boundaries.repartition.yaml

--- a/README.md
+++ b/README.md
@@ -94,6 +94,15 @@ atlas-object-partitioning describe-cells bin_boundaries.yaml --show-values
 atlas-object-partitioning describe-cells bin_boundaries.yaml --sort-by-size
 ```
 
+Update merged cell counts using an existing binning and merged-cell grouping
+(the input YAML must already contain `merged_cells.groups`), e.g. when the
+binning was defined on a smaller scan but you want counts from a larger scan:
+
+```bash
+atlas-object-partitioning repartition data18_13TeV:data18_13TeV.periodAllYear.physics_Main.PhysCont.DAOD_PHYSLITE.grp18_v01_p6697 \
+  bin_boundaries.yaml -n 500 -o bin_boundaries.repartition.yaml
+```
+
 Adjacent grid-cell merging example:
 
 ```bash


### PR DESCRIPTION
- Introduce a new command to update merged cell counts using an existing `bin_boundaries.yaml` file.

- Implement validation for the input YAML structure and contents.

- Add functionality to handle the output of updated bin boundaries to a specified file.

- Ensure compatibility with existing datasets and ServiceX instances.