### PR TITLE
Calculate usage and enhance command line history

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,17 @@ atlas-object-partitioning describe-cells bin_boundaries.yaml --show-values
 atlas-object-partitioning describe-cells bin_boundaries.yaml --sort-by-size
 ```
 
+Estimate the fraction of the dataset that must be read to satisfy object-count cuts.
+Cuts are inclusive (>= N); unspecified axes include all bins:
+
+```bash
+# Events with at least one electron
+atlas-object-partitioning calc_usage bin_boundaries.yaml --n-electrons 1
+
+# Events with at least two electrons and one muon
+atlas-object-partitioning calc_usage bin_boundaries.yaml --n-electrons 2 --n-muons 1
+```
+
 Update merged cell counts using an existing binning and merged-cell grouping
 (the input YAML must already contain `merged_cells.groups`), e.g. when the
 binning was defined on a smaller scan but you want counts from a larger scan:

--- a/src/atlas_object_partitioning/histograms.py
+++ b/src/atlas_object_partitioning/histograms.py
@@ -5,7 +5,7 @@ import awkward as ak
 import numpy as np
 import yaml
 from hist import BaseHist, Hist
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from rich.console import Console
 from rich.table import Table
 
@@ -127,15 +127,19 @@ class MergedCells(BaseModel):
 class BinBoundaries(BaseModel):
     axes: Dict[str, List[int]]
     merged_cells: Optional[MergedCells] = None
+    commands: List[str] = Field(default_factory=list)
 
 
 def write_bin_boundaries_yaml(
     boundaries: Dict[str, List[int]],
     file_path: str,
     merged_cells: Optional[MergedCells] = None,
+    commands: Optional[List[str]] = None,
 ) -> None:
     """Write the bin boundaries to ``file_path`` in YAML format."""
-    data = BinBoundaries(axes=boundaries, merged_cells=merged_cells)
+    if commands is None:
+        commands = []
+    data = BinBoundaries(axes=boundaries, merged_cells=merged_cells, commands=commands)
     with open(file_path, "w") as f:
         yaml.safe_dump(data.model_dump(), f)
 

--- a/src/atlas_object_partitioning/partition.py
+++ b/src/atlas_object_partitioning/partition.py
@@ -146,6 +146,129 @@ def _load_bin_boundaries_file(
     return cleaned_axes, merged_cells
 
 
+def _load_bin_boundaries_usage(
+    file_path: str,
+) -> Tuple[Dict[str, List[int]], List[Dict[str, object]]]:
+    try:
+        with open(file_path) as f:
+            data = yaml.safe_load(f)
+    except FileNotFoundError as exc:
+        raise typer.BadParameter(f"{file_path} does not exist.") from exc
+    if not isinstance(data, dict) or "axes" not in data:
+        raise typer.BadParameter(f"{file_path} does not contain axes data.")
+    axes = data["axes"]
+    if not isinstance(axes, dict) or not axes:
+        raise typer.BadParameter(f"{file_path} axes entry is not a mapping.")
+    cleaned_axes: Dict[str, List[int]] = {}
+    for axis, edges in axes.items():
+        if not isinstance(axis, str) or not axis:
+            raise typer.BadParameter(f"{file_path} has an invalid axis name.")
+        if not isinstance(edges, list):
+            raise typer.BadParameter(f"{file_path} axis {axis} edges are not a list.")
+        if len(edges) < 2:
+            raise typer.BadParameter(
+                f"{file_path} axis {axis} needs at least two bin edges."
+            )
+        try:
+            cleaned_axes[axis] = [int(edge) for edge in edges]
+        except (TypeError, ValueError) as exc:
+            raise typer.BadParameter(
+                f"{file_path} axis {axis} edges must be integers."
+            ) from exc
+    merged_cells = data.get("merged_cells")
+    if not isinstance(merged_cells, dict):
+        raise typer.BadParameter(f"{file_path} does not contain merged_cells data.")
+    groups = merged_cells.get("groups")
+    if not isinstance(groups, list) or not groups:
+        raise typer.BadParameter(f"{file_path} merged_cells.groups must be a list.")
+    cleaned_groups: List[Dict[str, object]] = []
+    for group in groups:
+        if not isinstance(group, dict) or "cells" not in group:
+            raise typer.BadParameter(
+                f"{file_path} merged_cells.groups entries must be mappings with cells."
+            )
+        cells = group["cells"]
+        if not isinstance(cells, list) or not cells:
+            raise typer.BadParameter(
+                f"{file_path} merged_cells group cells must be a non-empty list."
+            )
+        try:
+            fraction = float(group["fraction"])
+        except (KeyError, TypeError, ValueError) as exc:
+            raise typer.BadParameter(
+                f"{file_path} merged_cells group fraction must be numeric."
+            ) from exc
+        if not 0.0 <= fraction <= 1.0:
+            raise typer.BadParameter(
+                f"{file_path} merged_cells group fraction must be between 0 and 1."
+            )
+        cleaned_cells: List[Dict[str, int]] = []
+        for cell in cells:
+            if not isinstance(cell, dict):
+                raise typer.BadParameter(
+                    f"{file_path} merged_cells cell entries must be mappings."
+                )
+            cleaned_cell: Dict[str, int] = {}
+            for axis, value in cell.items():
+                if not isinstance(axis, str) or not axis:
+                    raise typer.BadParameter(
+                        f"{file_path} merged_cells cell axis names must be strings."
+                    )
+                try:
+                    cleaned_cell[axis] = int(value)
+                except (TypeError, ValueError) as exc:
+                    raise typer.BadParameter(
+                        f"{file_path} merged_cells cell values must be integers."
+                    ) from exc
+            cleaned_cells.append(cleaned_cell)
+        cleaned_groups.append({"cells": cleaned_cells, "fraction": fraction})
+    return cleaned_axes, cleaned_groups
+
+
+def _calc_usage_fraction(
+    boundaries: Dict[str, List[int]],
+    merged_groups: List[Dict[str, object]],
+    cuts: Dict[str, int],
+) -> float:
+    allowed_bins_by_axis: Dict[str, set[int]] = {}
+    for axis, edges in boundaries.items():
+        n_bins = len(edges) - 1
+        if axis in cuts:
+            min_value = cuts[axis]
+            allowed_bins_by_axis[axis] = {
+                idx for idx in range(n_bins) if edges[idx + 1] > min_value
+            }
+        else:
+            allowed_bins_by_axis[axis] = set(range(n_bins))
+
+    if any(not bins for bins in allowed_bins_by_axis.values()):
+        return 0.0
+
+    usage = 0.0
+    for group in merged_groups:
+        cells = group["cells"]
+        fraction = float(group["fraction"])
+        matched = False
+        for cell in cells:
+            if any(axis not in cell for axis in boundaries):
+                raise typer.BadParameter(
+                    "Merged cell group is missing axis entries for usage calculation."
+                )
+            if any(
+                cell[axis] < 0 or cell[axis] >= len(boundaries[axis]) - 1
+                for axis in boundaries
+            ):
+                raise typer.BadParameter(
+                    "Merged cell group has out-of-range bin indices."
+                )
+            if all(cell[axis] in allowed_bins_by_axis[axis] for axis in boundaries):
+                matched = True
+                break
+        if matched:
+            usage += fraction
+    return usage
+
+
 def _format_index_ranges(indices: List[int]) -> str:
     if not indices:
         return "-"
@@ -797,6 +920,66 @@ def describe_cells(
             *axis_parts,
         )
     Console().print(table)
+
+
+@app.command("calc_usage")
+def calc_usage(
+    bin_boundaries_file: str = typer.Argument(
+        ..., help="Path to the bin_boundaries.yaml file."
+    ),
+    n_electrons: Optional[int] = typer.Option(
+        None,
+        "--n-electrons",
+        help="Minimum number of electrons required (>= N).",
+    ),
+    n_muons: Optional[int] = typer.Option(
+        None,
+        "--n-muons",
+        help="Minimum number of muons required (>= N).",
+    ),
+    n_jets: Optional[int] = typer.Option(
+        None,
+        "--n-jets",
+        help="Minimum number of jets required (>= N).",
+    ),
+    n_large_jets: Optional[int] = typer.Option(
+        None,
+        "--n-large-jets",
+        help="Minimum number of large-R jets required (>= N).",
+    ),
+    n_photons: Optional[int] = typer.Option(
+        None,
+        "--n-photons",
+        help="Minimum number of photons required (>= N).",
+    ),
+    n_taus: Optional[int] = typer.Option(
+        None,
+        "--n-taus",
+        help="Minimum number of taus required (>= N).",
+    ),
+) -> None:
+    """Estimate dataset fraction needed to satisfy object-count cuts."""
+    boundaries, merged_groups = _load_bin_boundaries_usage(bin_boundaries_file)
+    cuts: Dict[str, int] = {}
+    for axis, value in (
+        ("n_electrons", n_electrons),
+        ("n_muons", n_muons),
+        ("n_jets", n_jets),
+        ("n_large_jets", n_large_jets),
+        ("n_photons", n_photons),
+        ("n_taus", n_taus),
+    ):
+        if value is None:
+            continue
+        if value < 0:
+            raise typer.BadParameter(f"{axis} cut must be >= 0.")
+        if axis not in boundaries:
+            raise typer.BadParameter(
+                f"{bin_boundaries_file} does not contain axis {axis}."
+            )
+        cuts[axis] = value
+    usage = _calc_usage_fraction(boundaries, merged_groups, cuts)
+    typer.echo(f"Usage fraction: {usage:.6f}")
 
 
 if __name__ == "__main__":

--- a/tests/atlas_object_partitioning/test_calc_usage.py
+++ b/tests/atlas_object_partitioning/test_calc_usage.py
@@ -1,0 +1,63 @@
+import yaml
+
+from atlas_object_partitioning.partition import _calc_usage_fraction
+
+
+def test_calc_usage_fraction_basic():
+    boundaries = {
+        "n_electrons": [0, 1, 3],
+        "n_muons": [0, 2, 4],
+    }
+    merged_groups = [
+        {"cells": [{"n_electrons": 0, "n_muons": 0}], "fraction": 0.4},
+        {"cells": [{"n_electrons": 1, "n_muons": 0}], "fraction": 0.3},
+        {"cells": [{"n_electrons": 1, "n_muons": 1}], "fraction": 0.3},
+    ]
+    usage = _calc_usage_fraction(boundaries, merged_groups, {"n_electrons": 1})
+    assert usage == 0.6
+
+    usage = _calc_usage_fraction(
+        boundaries, merged_groups, {"n_electrons": 1, "n_muons": 2}
+    )
+    assert usage == 0.3
+
+
+def test_calc_usage_fraction_out_of_range_cut():
+    boundaries = {"n_electrons": [0, 1, 2]}
+    merged_groups = [
+        {"cells": [{"n_electrons": 0}], "fraction": 0.7},
+        {"cells": [{"n_electrons": 1}], "fraction": 0.3},
+    ]
+    usage = _calc_usage_fraction(boundaries, merged_groups, {"n_electrons": 2})
+    assert usage == 0.0
+
+
+def test_calc_usage_yaml_roundtrip(tmp_path):
+    data = {
+        "axes": {"n_electrons": [0, 1, 3], "n_muons": [0, 2, 4]},
+        "merged_cells": {
+            "groups": [
+                {
+                    "cells": [{"n_electrons": 0, "n_muons": 0}],
+                    "count": 10,
+                    "fraction": 0.4,
+                },
+                {
+                    "cells": [{"n_electrons": 1, "n_muons": 1}],
+                    "count": 5,
+                    "fraction": 0.6,
+                },
+            ]
+        },
+    }
+    path = tmp_path / "bin_boundaries.yaml"
+    with open(path, "w") as f:
+        yaml.safe_dump(data, f)
+
+    with open(path) as f:
+        loaded = yaml.safe_load(f)
+
+    boundaries = loaded["axes"]
+    groups = loaded["merged_cells"]["groups"]
+    usage = _calc_usage_fraction(boundaries, groups, {"n_electrons": 1})
+    assert usage == 0.6

--- a/tests/atlas_object_partitioning/test_histograms.py
+++ b/tests/atlas_object_partitioning/test_histograms.py
@@ -32,7 +32,7 @@ def test_compute_bin_boundaries(tmp_path):
     write_bin_boundaries_yaml(boundaries, out_file)
     with open(out_file) as f:
         loaded = yaml.safe_load(f)
-    assert loaded == {"axes": boundaries, "merged_cells": None}
+    assert loaded == {"axes": boundaries, "merged_cells": None, "commands": []}
 
 
 def test_compute_bin_boundaries_all_zero():


### PR DESCRIPTION
- Introduce a command to estimate the fraction of the dataset needed for object-count cuts.
- Add a `commands` field to the bin boundaries data structure to track command line history.
- Update the YAML writing function to accommodate the new `commands` field.
- Enhance tests to validate the new usage calculation and ensure proper functionality of the command history.